### PR TITLE
docs: Add user-facing guide for Image Sync feature

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1,0 +1,52 @@
+# Image Sync - User Guide
+
+## What is Image Sync?
+
+Image Sync is an automated background service that keeps container images synchronized across the Kubernetes worker nodes in your cluster. It runs periodically without any user intervention.
+
+---
+
+## Why Was This Introduced?
+
+In a multi-node Kubernetes cluster, container images may exist on one worker node but not on another. This can cause:
+
+- **Delayed pod startup** – Pods scheduled on a node without the required image must wait for the image to be pulled
+- **Scheduling inefficiencies** – Kubernetes may schedule workloads on nodes that don't have the image cached, leading to longer startup times
+- **Inconsistent experience** – Same workload may start quickly on one node but slowly on another
+
+**Image Sync solves this** by ensuring all worker nodes have the same set of images, so your pods start quickly regardless of which node they're scheduled on.
+
+---
+
+## Which Images Are Synced?
+
+The following container images are automatically synchronized between worker nodes:
+
+| Image Source | Description |
+|--------------|-------------|
+| **Harbor Registry** | Internal images hosted on the headnode Harbor registry (images starting with `bcm11`) |
+| **NVIDIA NGC** | GPU-optimized images from NVIDIA NGC catalog (images starting with `nvcr.io/nvidia`) |
+
+> **Note:** Only images matching these prefixes are synced. External images from Docker Hub or other registries are not included.
+
+---
+
+## How Does This Benefit You?
+
+✅ **Faster pod startup** – Images are pre-cached on all nodes  
+✅ **Consistent performance** – No surprise delays when pods land on different nodes  
+✅ **Seamless experience** – Works automatically in the background  
+✅ **Resource efficiency** – Avoids redundant pulls during peak hours  
+
+---
+
+## Sync Schedule
+
+The synchronization runs automatically at regular intervals (typically every 30 minutes). No action is required from users.
+
+---
+
+## Questions?
+
+For any questions or issues related to image availability on the cluster, please contact your system administrator.
+

--- a/docs/dependency-diagram.md
+++ b/docs/dependency-diagram.md
@@ -137,3 +137,4 @@ flowchart LR
 | `MAX_LOG_SIZE` | `safe_append_log()` | 10MB |
 | `LOG_RETENTION_DAYS` | `cleanup_old_logs()` | 30 |
 
+


### PR DESCRIPTION
## Summary

Added a concise user guide document (`docs/USER-GUIDE.md`) to help cluster users understand the Image Sync feature without requiring technical knowledge of the implementation.

## Changes

- **New file:** `docs/USER-GUIDE.md` - User-friendly documentation explaining:
  - What Image Sync does
  - Why the feature was introduced
  - Which images are synchronized (Harbor and NVIDIA NGC)
  - Benefits for end users

## Why This Change?

The existing documentation (`README.md`, `system-architecture.md`) is targeted at administrators who install and configure the tool. Regular cluster users needed a simple document explaining:
- That this feature exists and runs automatically
- How it benefits their workloads (faster pod startup, consistent performance)
- Which images are covered by the sync

This document intentionally omits script details, configuration options, and CLI usage since Image Sync is managed by admins/cron jobs.

